### PR TITLE
Add DGurgurovSlovakSentiment classification task

### DIFF
--- a/mteb/tasks/Classification/__init__.py
+++ b/mteb/tasks/Classification/__init__.py
@@ -149,6 +149,7 @@ from .san.SanskritShlokasClassification import *
 from .sin.SinhalaNewsClassification import *
 from .sin.SinhalaNewsSourceClassification import *
 from .slk.CSFDSKMovieReviewSentimentClassification import *
+from .slk.DGurgurovSlovakSentiment import *
 from .slk.SlovakHateSpeechClassification import *
 from .slk.SlovakMovieReviewSentimentClassification import *
 from .slv.FrenkSlClassification import *

--- a/mteb/tasks/Classification/slk/DGurgurovSlovakSentiment.py
+++ b/mteb/tasks/Classification/slk/DGurgurovSlovakSentiment.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from mteb.abstasks.AbsTaskClassification import AbsTaskClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class DGurgurovSlovakSentiment(AbsTaskClassification):
+    metadata = TaskMetadata(
+        name="DGurgurovSlovakSentiment",
+        description="Sentiment Analysis Data for the Slovak Language. Binary sentiment classification dataset with ~5,000 samples used for improving word embeddings with graph knowledge for low resource languages.",
+        reference="https://aclanthology.org/W19-3716/",
+        dataset={
+            "path": "DGurgurov/slovak_sa",
+            "revision": "c96cf94e6fdf19611a078075de00c8fc3b0f613c",
+        },
+        type="Classification",
+        category="s2s",
+        modalities=["text"],
+        date=("2019-01-01", "2019-08-01"),
+        eval_splits=["test"],
+        eval_langs=["slk-Latn"],
+        main_score="accuracy",
+        domains=["Reviews", "Written"],
+        task_subtypes=["Sentiment/Hate speech"],
+        license="mit",
+        annotations_creators="human-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation=r"""
+@inproceedings{pecar-etal-2019-improving,
+    title = "Improving Sentiment Classification in {S}lovak Language",
+    author = "Pecar, Samuel and Simko, Marian and Bielikova, Maria",
+    booktitle = "Proceedings of the 7th Workshop on Balto-Slavic Natural Language Processing",
+    month = aug,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    pages = "114--119",
+    doi = "10.18653/v1/W19-3716"
+}
+""",
+    )
+
+    def dataset_transform(self) -> None:
+        self.dataset = self.stratified_subsampling(
+            self.dataset, seed=self.seed, splits=["test"]
+        )


### PR DESCRIPTION
Add binary sentiment classification task for Slovak language based on the DGurgurov/slovak_sa dataset. The dataset contains ~5k samples with human-annotated sentiment labels from the paper "Improving Sentiment Classification in Slovak Language" (Pecar et al., 2019, ACL W19-3716).

Dataset details:
- 3,560 training samples
- 522 validation samples
- 1,042 test samples
- Binary classification (positive/negative)
- MIT license