### PR TITLE
Add EuroParlVote Slovak classification tasks

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -723,6 +723,8 @@ MTEB_SLK = Benchmark(
                 "SlovakParlaSentClassification",
                 "MultiEupSlovakPartyClassification",
                 "MultiEupSlovakGenderClassification",
+                "SlovakEuroParlVoteGenderClassification",
+                "SlovakEuroParlVotePositionClassification",
                 # Reranking
                 "SkQuadReranking",
                 "SlovakFactCheckReranking",

--- a/mteb/tasks/Classification/__init__.py
+++ b/mteb/tasks/Classification/__init__.py
@@ -150,8 +150,8 @@ from .sin.SinhalaNewsClassification import *
 from .sin.SinhalaNewsSourceClassification import *
 from .slk.CSFDSKMovieReviewSentimentClassification import *
 from .slk.DGurgurovSlovakSentiment import *
-from .slk.EuroParlVoteClassification import *
 from .slk.MultiEupSlovakClassification import *
+from .slk.SlovakEuroParlVoteClassification import *
 from .slk.SlovakHateSpeechClassification import *
 from .slk.SlovakMovieReviewSentimentClassification import *
 from .slk.SlovakParlaSentClassification import *

--- a/mteb/tasks/Classification/slk/SlovakEuroParlVoteClassification.py
+++ b/mteb/tasks/Classification/slk/SlovakEuroParlVoteClassification.py
@@ -1,4 +1,4 @@
-"""EuroParlVote Slovak classification tasks.
+"""Slovak EuroParlVote classification tasks.
 
 This module implements two classification tasks based on the EuroParlVote dataset,
 using Slovak speeches from the European Parliament to predict:
@@ -107,13 +107,15 @@ class _EuroParlVoteSlovakMixin:
             del self.dataset["validation"]
 
 
-class EuroParlVoteGenderClassification(_EuroParlVoteSlovakMixin, AbsTaskClassification):
+class SlovakEuroParlVoteGenderClassification(
+    _EuroParlVoteSlovakMixin, AbsTaskClassification
+):
     """Gender classification task using EuroParlVote Slovak speeches."""
 
     target_column: ClassVar[str] = "gender"
 
     metadata = TaskMetadata(
-        name="EuroParlVoteGenderClassification",
+        name="SlovakEuroParlVoteGenderClassification",
         description="Binary classification task to predict the gender of Members of the European Parliament from Slovak speeches in the EuroParlVote dataset. Uses only speeches delivered in Slovak.",
         reference="https://arxiv.org/abs/2509.06164",
         dataset={
@@ -137,7 +139,7 @@ class EuroParlVoteGenderClassification(_EuroParlVoteSlovakMixin, AbsTaskClassifi
     )
 
 
-class EuroParlVotePositionClassification(
+class SlovakEuroParlVotePositionClassification(
     _EuroParlVoteSlovakMixin, AbsTaskClassification
 ):
     """Vote position classification task using EuroParlVote Slovak speeches."""
@@ -145,7 +147,7 @@ class EuroParlVotePositionClassification(
     target_column: ClassVar[str] = "position"
 
     metadata = TaskMetadata(
-        name="EuroParlVotePositionClassification",
+        name="SlovakEuroParlVotePositionClassification",
         description="Binary classification task to predict the vote position (FOR/AGAINST) from Slovak speeches in the EuroParlVote dataset. Uses only speeches delivered in Slovak.",
         reference="https://arxiv.org/abs/2509.06164",
         dataset={


### PR DESCRIPTION
Implements two classification tasks based on the EuroParlVote dataset using Slovak speeches from the European Parliament:

- EuroParlVoteGenderClassification: Binary gender prediction (MALE/FEMALE)
- EuroParlVotePositionClassification: Binary vote position (FOR/AGAINST)

Dataset: unimelb-nlp/EuroParlVote (Yang et al., ICNLSP 2025) Uses Speech field from speeches delivered in Slovak (Language=SK).

Train/test split: 257 train, 26 test samples

Reference: https://aclanthology.org/2025.icnlsp-1.41/