### PR TITLE
Add DemagogSKNLI PairClassification task

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -713,6 +713,7 @@ MTEB_SLK = Benchmark(
                 # Pair Classification
                 "SlovakNLI",
                 "SlovakRTE",
+                "DemagogSKNLI",
                 # Classification
                 "SlovakHateSpeechClassification.v2",
                 "SlovakMovieReviewSentimentClassification.v2",

--- a/mteb/tasks/PairClassification/__init__.py
+++ b/mteb/tasks/PairClassification/__init__.py
@@ -28,6 +28,7 @@ from .pol.PolishPC import *
 from .por.Assin2RTE import *
 from .por.SickBrPC import *
 from .rus.TERRa import *
+from .slk.DemagogSKNLI import *
 from .slk.SlovakNLI import *
 from .slk.SlovakRTE import *
 from .vie.SprintDuplicateQuestionsPCVN import *

--- a/mteb/tasks/PairClassification/slk/DemagogSKNLI.py
+++ b/mteb/tasks/PairClassification/slk/DemagogSKNLI.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datasets import DatasetDict
+
+from mteb.abstasks.AbsTaskPairClassification import AbsTaskPairClassification
+from mteb.abstasks.TaskMetadata import TaskMetadata
+
+
+class DemagogSKNLI(AbsTaskPairClassification):
+    metadata = TaskMetadata(
+        name="DemagogSKNLI",
+        description=(
+            "Slovak Natural Language Inference dataset created from Demagog.sk fact-checking data. "
+            "The dataset consists of evidence-claim pairs where professional fact-checkers' analysis "
+            "(evidence) is paired with political statements (claims). Labels indicate whether the "
+            "evidence supports or refutes the claim. Only clear verdicts (Pravda/Nepravda) are included, "
+            "filtering out ambiguous cases (Zavádzajúce/Neoveriteľné)."
+        ),
+        reference="https://huggingface.co/datasets/NaiveNeuron/DemagogSK",
+        dataset={
+            "path": "NaiveNeuron/DemagogSK",
+            "revision": "0f9e0f902da3aca1fd6c940cd852e95c9ef5327f",
+        },
+        type="PairClassification",
+        category="s2s",
+        modalities=["text"],
+        date=("2010-03-14", "2025-10-16"),
+        eval_splits=["test"],
+        eval_langs=["slk-Latn"],
+        main_score="max_ap",
+        domains=["Government", "News", "Written"],
+        task_subtypes=["Claim verification"],
+        license="not specified",
+        annotations_creators="expert-annotated",
+        dialect=[],
+        sample_creation="found",
+        bibtex_citation="",
+        prompt="Given a fact-checker's analysis (evidence), determine if it supports or refutes the political claim",
+    )
+
+    def dataset_transform(self):
+        """Transform DemagogSK into evidence-claim NLI pairs."""
+        _dataset = {}
+
+        for split in self.metadata.eval_splits:
+            hf_dataset = self.dataset[split]
+
+            # Filter to only include clear verdicts (Pravda/Nepravda)
+            # and ensure both evidence and claim are present
+            hf_dataset = hf_dataset.filter(
+                lambda x: (
+                    x.get("verdict") in ["Pravda", "Nepravda"]
+                    and x.get("analysis_text")
+                    and x.get("statement")
+                    and len(str(x.get("analysis_text", "")).strip()) > 0
+                    and len(str(x.get("statement", "")).strip()) > 0
+                )
+            )
+
+            # Map verdicts: Pravda (true) -> 1 (SUPPORTS), Nepravda (false) -> 0 (REFUTES)
+            hf_dataset = hf_dataset.map(
+                lambda example: {"label": 1 if example["verdict"] == "Pravda" else 0}
+            )
+
+            _dataset[split] = [
+                {
+                    "sentence1": hf_dataset["analysis_text"],  # Evidence/reasoning
+                    "sentence2": hf_dataset["statement"],      # Claim to verify
+                    "labels": hf_dataset["label"],
+                }
+            ]
+
+        self.dataset = DatasetDict(_dataset)


### PR DESCRIPTION
Creates a Slovak Natural Language Inference task from Demagog.sk fact-checking data. The task pairs professional fact-checker analysis (evidence) with political statements (claims) to evaluate whether the evidence supports or refutes the claim.

- Uses analysis_text as evidence and statement as claim
- Binary classification: Pravda (supports) vs Nepravda (refutes)
- Filters out ambiguous verdicts (Zavádzajúce, Neoveriteľné)
- Dataset: NaiveNeuron/DemagogSK (3,085 test examples after filtering)
- Task type: PairClassification (evidence-claim verification)
- Added to MTEB_SLK benchmark (now 24 tasks total, 3 PairClassification tasks)