### PR TITLE
Add 5 multilingual bitext mining tasks to MTEB_SLK benchmark

### DIFF
--- a/mteb/benchmarks/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks/benchmarks.py
@@ -732,8 +732,13 @@ MTEB_SLK = Benchmark(
                 "PravdaSKURLClustering",
                 "SlovakSumURLClustering",
                 # TODO: SMESumURLClustering
-                # BitexMining
+                # BitextMining
                 "OpusSlovakEnglishBitextMining",
+                "Tatoeba",
+                "FloresBitextMining",
+                "NTREXBitextMining",
+                "WebFAQBitextMiningQuestions",
+                "WebFAQBitextMiningQAs",
             ],
         )
     ),


### PR DESCRIPTION
Expands Slovak bitext mining coverage from 1 to 6 tasks (2K→493K samples):

- Tatoeba: 1K slk-eng pairs
- FloresBitextMining: 406 language pairs × 1,012 samples = 411K
- NTREXBitextMining: 26 Slavic pairs × 1,997 samples = 52K
- WebFAQBitextMiningQuestions: 11 pairs, 13K FAQ questions
- WebFAQBitextMiningQAs: 11 pairs, 13K question-answer pairs